### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/tools/backend/api.py
+++ b/tools/backend/api.py
@@ -3,8 +3,10 @@ from scraper.playwright_scraper import fetch_profile_and_posts
 from backend.crud import upsert_account, insert_posts
 from backend.db import create_tables
 import os
+import logging
 
 app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
 create_tables()
 
 @app.route('/scrape', methods=['POST'])
@@ -21,7 +23,8 @@ def scrape():
             insert_posts(acc_id, posts)
         return jsonify({'profile': profile, 'posts_count': len(posts)})
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logging.exception("Error in /scrape endpoint")
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 @app.route('/health')
 def health():


### PR DESCRIPTION
Potential fix for [https://github.com/Brandnbloom/brandnbloom/security/code-scanning/1](https://github.com/Brandnbloom/brandnbloom/security/code-scanning/1)

To fix the problem, we should avoid sending the raw exception message to the client. Instead, we should log the exception details on the server for debugging purposes and return a generic error message to the client. This can be done by replacing the response in the `except` block with a generic message, and adding a logging statement to record the exception details. The best way to log the error is to use Python's built-in `logging` module, which is standard and well-known. The changes should be made in the `/scrape` endpoint in `tools/backend/api.py`, specifically in the `except` block. Additionally, we need to ensure that the `logging` module is imported and configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
