### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/venv/pip/-internal/network/session.py
+++ b/venv/pip/-internal/network/session.py
@@ -423,7 +423,7 @@ class PipSession(requests.Session):
             string came from.
         """
         if not suppress_logging:
-            msg = f"adding trusted host: {host!r}"
+            msg = "adding trusted host"
             if source is not None:
                 msg += f" (from {source})"
             logger.info(msg)


### PR DESCRIPTION
Potential fix for [https://github.com/Brandnbloom/brandnbloom/security/code-scanning/16](https://github.com/Brandnbloom/brandnbloom/security/code-scanning/16)

To fix the problem, we should avoid logging the full value of `host` directly, as it may contain sensitive information. Instead, we can log a redacted or generic message, or simply omit the host value from the log. If logging is still desired for debugging, we can log only non-sensitive parts (e.g., the fact that a host was added, but not its value), or redact the host value (e.g., log only the domain, or mask the value). The best fix is to remove the direct inclusion of `host` in the log message on line 426, and replace it with a generic message such as "adding trusted host" without the host value, or with a redacted version. This change should be made in the `add_trusted_host` method in `venv/pip/-internal/network/session.py`, lines 426–429.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
